### PR TITLE
Add distPkgFiles config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Options:
     "verbose": false,
     "force": false,
     "pkgFiles": ["package.json"],
+    "distPkgFiles": undefined, /* Defaults to pkgFiles */
     "increment": "patch",
     "commitMessage": "Release %s",
     "tagName": "%s",

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -98,7 +98,9 @@ function bump(file, version) {
                 log.warn('There was a problem reading ' + file);
                 log.debug(err);
             }).then(function(data) {
-                return fn.call(fs.writeFile, file, JSON.stringify(data, null, 2) + '\n');
+                if(data){
+                    return fn.call(fs.writeFile, file, JSON.stringify(data, null, 2) + '\n');
+                }
             }).catch(function(err) {
                 log.warn('There was a problem bumping the version in ' + file);
                 log.debug(err);

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -92,7 +92,6 @@ function getGenericTasks(options) {
         isRepo: git.isGitRepo,
         hasChanges: git.hasChanges,
         build: shell.build.bind(null, options.buildCommand),
-        bump: shell.bump.bind(null, options.pkgFiles, options.version),
         status: git.status,
         stageAll: git.stageAll,
         commit: git.commit.bind(null, '.', options.commitMessage, options.version),
@@ -108,6 +107,7 @@ function getSrcRepoTasks(options) {
     var isPublish = !(options['non-interactive'] && !options.publish) && !options.distRepo;
 
     return _.extend({}, getGenericTasks(options), {
+        bump: shell.bump.bind(null, options.pkgFiles, options.version),
         stage: git.stage.bind(null, options.pkgFiles),
         release: options.githubRelease ? git.release.bind(null, options) : noop,
         publish: isPublish ? shell.npmPublish : noop
@@ -117,8 +117,10 @@ function getSrcRepoTasks(options) {
 function getDistRepoTasks(options) {
 
     var isPublish = !(options['non-interactive'] && !options.publish) && !!options.distRepo;
+    var distPkgFiles = options.distPkgFiles || options.pkgFiles;
 
     return _.extend({}, getGenericTasks(options), {
+        bump: shell.bump.bind(null, distPkgFiles, options.version),
         clone: git.clone.bind(null, options.distRepo, options.distStageDir),
         copy: shell.copy.bind(null, options.distFiles, {cwd: options.distBase}, options.distStageDir),
         pushd: shell.pushd.bind(null, options.distStageDir),


### PR DESCRIPTION
This fixes two issues:
1. when one of the pkgFiles doesn't exists, it created a new file with content of `undefined`
2. added config for distPkgFiles, because I don't want warning for files that are intended to be missing either from source repo, or dist repo. Also it caused an error with git add anyway if the file didn't exist. distPkgFiles default to distFiles if not defined to be backwards compatible.