### PR TITLE
Support for GithubEnterprise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp
+node_modules

--- a/lib/git.js
+++ b/lib/git.js
@@ -4,7 +4,7 @@ var util = require('./util'),
     when = require('when'),
     sequence = require('when/sequence'),
     GitHubApi = require('github'),
-    repoPathParse = require('repo-path-parse'),
+    parseRepo = require('parse-repo'),
     log = require('./log');
 
 var noop = when.resolve(true),
@@ -194,9 +194,9 @@ function getChangelog(options) {
 
 function release(options, remoteUrl) {
 
-    var repo = repoPathParse(remoteUrl);
+    var repo = parseRepo(remoteUrl);
 
-    log.execution('node-github releases#createRelease', util.format('%s/%s', repo.owner, repo.repo));
+    log.execution('node-github releases#createRelease', util.format('%s/%s', repo.owner, repo.project));
 
     var githubClient = initGithubClient(),
         success = false,
@@ -211,7 +211,7 @@ function release(options, remoteUrl) {
             return when.promise(function(resolve) {
                 githubClient.releases.createRelease({
                     owner: repo.owner,
-                    repo: repo.repo,
+                    repo: repo.project,
                     tag_name: util.format(options.tagName, options.version),
                     name: util.format(options.github.releaseName, options.version),
                     body: config.process.get('changelog')

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.6.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "repo-path-parse": "^1.0.1",
+    "parse-repo": "^1.0.1",
     "semver": "^5.1.0",
     "shelljs": "^0.7.0",
     "when": "^3.7.7"


### PR DESCRIPTION
The 3rd party module `repo-path-parse` only understands github.com URLs.

While trying to release to a github enterprise installation (github.com on-premises) that has another domain than github.com, `repo-path-parse` cannot understand it

By switching to `parse-repo` this is solved

Examples:
`parse-repo`: https://tonicdev.com/5788ea6e2a91251300f25bb0/5788ea6e2a91251300f25bb1
`repo-path-parse`: https://tonicdev.com/5788ea6e2a91251300f25bb0/5788eca636f3d6120002b014