### PR TITLE
Only determine revision range when needed

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -174,23 +174,31 @@ function getGithubToken(tokenRef) {
 }
 
 function getChangelog(options) {
-    if(options.changelogCommand) {
-        var prevVersion = config.process.get('prevVersion') || options.prevVersion;
-        var prevTag = util.format(options.tagName, prevVersion);
-        return tagExists(prevTag).then(function(hasTag) {
-            var command = options.changelogCommand.replace(/\[REV_RANGE\]/, hasTag ? prevTag + '...HEAD' : '');
-            return run(command).then(function(result) {
-                process.stdout.write('\n');
-                config.process.set('changelog', result.output);
-                return options;
-            })
-        }).catch(function(err) {
-            log.warn('Probably the current version in package.json is not a known tag in the repository.');
-            throw new Error('Could not create changelog from latest tag (' + prevTag + ') to HEAD.');
-        })
+  function runChangelogCommand (command) {
+    return run(command).then(function(result) {
+        process.stdout.write('\n');
+        config.process.set('changelog', result.output);
+        return options;
+    })
+  }
+
+  if(options.changelogCommand) {
+    if(options.changelogCommand.match(/\[REV_RANGE\]/) {
+      var prevVersion = config.process.get('prevVersion') || options.prevVersion;
+      var prevTag = util.format(options.tagName, prevVersion);
+      return tagExists(prevTag).then(function(hasTag) {
+          var command = options.changelogCommand.replace(/\[REV_RANGE\]/, hasTag ? prevTag + '...HEAD' : '');
+          return runChangelogCommand(command);
+      }).catch(function(err) {
+          log.warn('Probably the current version in package.json is not a known tag in the repository.');
+          throw new Error('Could not create changelog from latest tag (' + prevTag + ') to HEAD.');
+      })
     } else {
-        return noop;
+      return runChangelogCommand(options.changelogCommand);
     }
+  } else {
+    return noop;
+  }
 }
 
 function release(options, remoteUrl) {


### PR DESCRIPTION
Determining the changelog revision can fail, and it is not needed only if the user added the template.

This pull request modifies the behavior of getChangelog() so it only tries to determine the revisions if the changelogCommand contains the template.