### PR TITLE
Switch for Enterprise and GitHub host in GitHub API

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -146,13 +146,14 @@ function pushTags(version, pushUrl) {
     });
 }
 
-function initGithubClient() {
+function initGithubClient(repo) {
     if(!_githubClient) {
         _githubClient = new GitHubApi({
             version: '3.0.0',
             debug: config.isDebug(),
-            protocol: 'https',
-            host: 'api.github.com',
+            protocol: repo.protocol,
+            host: repo.host === 'github.com' ? '' : repo.host,
+            pathPrefix: repo.host === 'github.com' ? '' : '/api/v3',
             timeout: 10000,
             headers: {
                 'user-agent': 'webpro/release-it'
@@ -207,7 +208,7 @@ function release(options, remoteUrl) {
 
     log.execution('node-github releases#createRelease', repo.repository);
 
-    var githubClient = initGithubClient(),
+    var githubClient = initGithubClient(repo),
         success = false,
         attempts = 3;
 


### PR DESCRIPTION
If site is github.com, use node-github default (api.github.com).
If site is other (ie. Enterprise) use repo.host.

This closes #74 