### PR TITLE
add option to disable commiting and pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Options:
     "pkgFiles": ["package.json"],
     "increment": "patch",
     "prereleaseId": null,
+    "noCommit": false,
     "commitMessage": "Release %s",
     "tagName": "%s",
     "tagAnnotation": "Release %s",
@@ -143,6 +144,7 @@ Notes:
 * If `src.pushRepo` has a falsey value, just `git push` is used. Otherwise, it's the url or name of a remote in `git push <src.pushRepo>`.
 * If `dist.pkgFiles` has a falsey value, it will take the value of `pkgFiles`.
 * The `after*/before*` commands are executed from the root/working directory of the source or distribution repository. The `beforeStageCommand` is executed before files are staged for commit, and after a version bump.
+* If `noCommit` has a truthy value, nothing is committed or pushed. The created tag will point to the current commit.
 
 ### Distribution Repository
 
@@ -177,7 +179,7 @@ export GITHUB_TOKEN="f941e0..."
 
 In non-interactive mode, the release is created only for the source repository.
 
-### Local configuration file 
+### Local configuration file
 
 Place a `.release.json` file in your project root, and **Release It** will use it to overwrite default settings. You can use `--config` if you want to use another filename/location. Most options can be set on the command-line (these will have highest priority).
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -157,13 +157,14 @@ function releaseDistRepo(options) {
 }
 
 function getGenericTasks(options) {
+    var isCommit = !options.noCommit
     return {
         isRepo: git.isGitRepo,
         status: git.status,
         stageDir: git.stageDir,
-        commit: git.commit.bind(null, '.', options.commitMessage, options.version),
+        commit: isCommit ? git.commit.bind(null, '.', options.commitMessage, options.version) : noop,
         tag: git.tag.bind(null, options.version, options.tagName, options.tagAnnotation),
-        push: git.push.bind(null, options.remoteUrl),
+        push: isCommit ? git.push.bind(null, options.remoteUrl) : noop, // nothing to push
         pushTags: git.pushTags.bind(null, options.version),
         popd: shell.popd
     }
@@ -173,7 +174,8 @@ function getSrcRepoTasks(options) {
 
     var isMakeBaseDir = options.buildCommand && options.dist.repo && options.dist.baseDir,
         isStageBuildDir = !!options.buildCommand && !options.dist.repo && options.dist.baseDir,
-        isPublish = !options['non-interactive'] || (options.npm.publish && !options.dist.repo);
+        isPublish = !options['non-interactive'] || (options.npm.publish && !options.dist.repo),
+        isCommit = !options.noCommit;
 
     return _.extend({}, getGenericTasks(options), {
         mkCleanDir: isMakeBaseDir ? shell.mkCleanDir.bind(null, options.dist.baseDir) : noop,
@@ -185,7 +187,7 @@ function getSrcRepoTasks(options) {
         stage: git.stage.bind(null, options.pkgFiles),
         stageDir: isStageBuildDir ? git.stageDir.bind(null, options.dist.baseDir) : noop,
         hasChanges: git.hasChanges.bind(null, 'src'),
-        push: git.push.bind(null, options.remoteUrl, options.src.pushRepo),
+        push: isCommit ? git.push.bind(null, options.remoteUrl, options.src.pushRepo) : noop,
         pushTags: git.pushTags.bind(null, options.version, options.src.pushRepo),
         release: options.github.release ? git.release.bind(null, options, options.remoteUrl) : noop,
         publish: isPublish ? shell.npmPublish.bind(null, options.npm.publishPath, options.npm.tag) : noop,


### PR DESCRIPTION
Added an option
```
noCommit
```
which is when set to a truthy value, disables the `commit` and the `push` tasks.