### PR TITLE
Add github prerelease option

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -223,7 +223,8 @@ function release(options, remoteUrl) {
                     repo: repo.project,
                     tag_name: util.format(options.tagName, options.version),
                     name: util.format(options.github.releaseName, options.version),
-                    body: config.process.get('changelog')
+                    body: config.process.get('changelog'),
+                    prerelease: options.github.prerelease,
                 }, function(err, response) {
                     if(err) {
                         log[attempt + 1 < attempts ? 'warn' : 'error'](err.defaultMessage + ' (Attempt ' + (attempt + 1) + ' of ' + attempts + ')');


### PR DESCRIPTION
Adds a boolean `github.prerelease` option

to create prereleases on github
https://developer.github.com/v3/repos/releases/#create-a-release