### PR TITLE
Allow options when using release-it as Node.js module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,14 +3,14 @@ import { config } from './config';
 import runTasks from './tasks';
 import track, { trackException } from './metrics';
 
-export default function release() {
+export default function release(options) {
   if (config.isShowVersion) {
     version();
   } else if (config.isShowHelp) {
     help();
   } else {
     track('start');
-    return runTasks().then(() => track('end'), trackException);
+    return runTasks(options).then(() => track('end'), trackException);
   }
   return Promise.resolve();
 }

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -5,15 +5,16 @@ import * as git from './git';
 import * as githubClient from './github-client';
 import prompt from './prompt';
 import * as util from './util';
-import { config } from './config';
+import Config from './config';
 import * as log from './log';
 import { debug, debugConfig } from './debug';
 import spinner, { getSpinner } from './spinner';
 
 const noop = () => Promise.resolve();
 
-export default async function runTasks() {
+export default async function runTasks(options) {
   let initSpinner;
+  const config = options ? new Config(options) : Config.config;
 
   try {
     const { options, isInteractive, isVerbose } = config;


### PR DESCRIPTION
Hey Lars,

I’m using `release-it` as part of a personal CLI to deploy a project. The deploy steps include test runs and actual remote command exeution. I use `release-it` in non-interactive mode to bump the version, commit git changes, tag git release and push the changes.

This PR adds an `options` object as a parameter to `tasks`. It allows users to customize the default behavior of `release-it` when using it as a Node.js module and not from the command line.

I appreciate any feedback if it doesn’t meet your intentions with `release-it` 😃 
Thank you!