### PR TITLE
Fix default options overriding

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -104,11 +104,11 @@ export default class Config {
         'non-interactive': isCI
       },
       this.localOptions,
-      this.defaultOptions,
       {
         name: this.npm.name || path.basename(process.cwd()),
         npm: this.npm
-      }
+      },
+      this.defaultOptions
     );
   }
 


### PR DESCRIPTION
According to lodash docs (https://lodash.com/docs/#defaultsDeep) defaults should go as a last argument to _.defaultsDeep() function.