### PR TITLE
adjust path to stage directory

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const repoPathParse = require('parse-repo');
 const _ = require('lodash');
 const { bump, runTemplateCommand: run, pushd, copy, npmPublish, popd, mkTmpDir } = require('./shell');
@@ -89,7 +90,7 @@ module.exports = async options => {
     if (dist.repo) {
       const { pkgFiles, beforeStageCommand } = dist;
       await spinner(dist.repo, () => git.clone(dist.repo, stageDir), 'Clone (dist repo)');
-      await copy(dist.files, { cwd: dist.baseDir }, stageDir);
+      await copy(dist.files, { cwd: dist.baseDir }, path.join('..', stageDir));
       await pushd(stageDir);
       await bump(pkgFiles);
       await spinner(beforeStageCommand, () => run(beforeStageCommand), `Command (${beforeStageCommand})`);


### PR DESCRIPTION
After upgrading from an older version of the release-it tool I noticed the dist files are no longer being copied to dist repo. This happens because files are copied relative to dist.baseDir. stageDir in the default configuration is part of baseDir parent directory, which means the path needs to be adjusted.

This works with the assumption that baseDir is always a direct child of the root directory.