### PR TITLE
fix interactive dist release tasks

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -165,7 +165,10 @@ module.exports = async options => {
         await prompt('dist', 'commit', commit);
         await prompt('dist', 'tag', tag);
         await prompt('dist', 'push', push);
-        await prompt('dist', 'release', [release, uploadAssets]);
+        await prompt('dist', 'release', async () => {
+          const releaseInfo = await release();
+          return releaseInfo && (await uploadAssets(releaseInfo.id));
+        });
         await prompt('dist', 'publish', publish);
       }
 


### PR DESCRIPTION
The process of releasing with a distribution repository fails because tasks are passed as an array.