### PR TITLE
make dist repo bump to the same version

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -91,7 +91,7 @@ module.exports = async options => {
       await spinner(dist.repo, () => git.clone(dist.repo, stageDir), 'Clone (dist repo)');
       await copy(dist.files, { cwd: dist.baseDir }, stageDir);
       await pushd(stageDir);
-      await bump(pkgFiles);
+      await bump(pkgFiles, version);
       await spinner(beforeStageCommand, () => run(beforeStageCommand), `Command (${beforeStageCommand})`);
       await git.stageDir();
       await git.hasChanges('dist');


### PR DESCRIPTION
The version of the dist repo is no longer in sync with the src repo's version.