### PR TITLE
Configurable prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .tmp*
 coverage
 package-lock.json
+node_modules

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ By default, release-it is interactive and allows you to confirm each task before
 
 <img src="./assets/release-it.png?raw=true" height="148">
 
+The prompted questions can be configured so that only some of them are shown (see the `Option` column
+in the table bellow).
+
 On a Continuous Integration (CI) environment, or by using the `-n` option, this is fully automated. No prompts are shown and the configured tasks will be executed. This is demonstrated in the first animation above. An overview of the default tasks:
 
 Task | Option | Default | Prompt | Default

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -44,7 +44,8 @@ const prompts = {
   }
 };
 
-module.exports = async (subject, promptName, task) => {
+module.exports = async (shouldPrompt, subject, promptName, task) => {
+  if (!shouldRun) return noop;
   const prompt = Object.assign({}, prompts[promptName], {
     name: promptName,
     message: prompts[promptName].message(subject, options.version),

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -45,7 +45,7 @@ const prompts = {
 };
 
 module.exports = async (shouldPrompt, subject, promptName, task) => {
-  if (!shouldRun) return noop;
+  if (!shouldPrompt) return noop;
   const prompt = Object.assign({}, prompts[promptName], {
     name: promptName,
     message: prompts[promptName].message(subject, options.version),

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -37,7 +37,7 @@ module.exports = async options => {
       Object.assign(options, parsed);
     } else if (!parsed.version && isInteractive) {
       log.warn('Unable to find an existing Git tag, or package.json#version. No or invalid version provided.');
-      await prompt('src', 'version', version => {
+      await prompt(true, 'src', 'version', version => {
         Object.assign(options, {
           version
         });
@@ -74,7 +74,7 @@ module.exports = async options => {
     }
 
     if (isInteractive) {
-      await prompt('src', 'ready', () => {
+      await prompt(true, 'src', 'ready', () => {
         throw new Error('Cancelled (no changes were made).');
       });
     }
@@ -118,17 +118,17 @@ module.exports = async options => {
         await spinner(npm.publish, publish, 'npm publish');
       }
     } else {
-      await prompt('src', 'status', status);
-      await prompt('src', 'commit', commit);
-      await prompt('src', 'tag', tag);
-      await prompt('src', 'push', push);
-      await prompt('src', 'release', async () => {
+      await prompt(true, 'src', 'status', status);
+      await prompt(src.commit, 'src', 'commit', commit);
+      await prompt(src.tag, 'src', 'tag', tag);
+      await prompt(src.push, 'src', 'push', push);
+      await prompt(github.release, 'src', 'release', async () => {
         const releaseInfo = await release();
         return releaseInfo && (await uploadAssets(releaseInfo.id));
       });
 
       if (!npm.private) {
-        await prompt('src', 'publish', publish);
+        await prompt(npm.publish, 'src', 'publish', publish);
       }
     }
 
@@ -162,15 +162,15 @@ module.exports = async options => {
         await spinner(releaseInfo, () => uploadAssets(releaseInfo.id), 'GitHub upload assets (dist repo)');
         await spinner(npm.publish, publish, 'npm publish (dist repo)');
       } else {
-        await prompt('dist', 'status', status);
-        await prompt('dist', 'commit', commit);
-        await prompt('dist', 'tag', tag);
-        await prompt('dist', 'push', push);
-        await prompt('dist', 'release', async () => {
+        await prompt(true, 'dist', 'status', status);
+        await prompt(dist.commit, 'dist', 'commit', commit);
+        await prompt(shouldTag, 'dist', 'tag', tag);
+        await prompt(dist.push, 'dist', 'push', push);
+        await prompt(github.release, 'dist', 'release', async () => {
           const releaseInfo = await release();
           return releaseInfo && (await uploadAssets(releaseInfo.id));
         });
-        await prompt('dist', 'publish', publish);
+        await prompt(npm.publish, 'dist', 'publish', publish);
       }
 
       await spinner(afterReleaseCommand, () => run(afterReleaseCommand), `Command (${afterReleaseCommand})`);


### PR DESCRIPTION
Follow-up of #180 

The prompts should follow the options passed to the tasks runner.
@webpro Fell free to edit the README modifications, not sure how to best explain this.