### PR TITLE
Return results from the tasks runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .tmp*
 coverage
 package-lock.json
+node_modules

--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -113,7 +113,7 @@ const uploadAsset = ({ releaseId, repo, github, filePath }) => {
   const name = path.basename(filePath);
   const { owner, project } = repo;
   const { token } = github;
-  const host = github.host || repo.host;    
+  const host = github.host || repo.host;
   const githubClient = getGithubClient({ host, token });
 
   return retry(

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,14 +3,22 @@ const { config } = require('./config');
 const runTasks = require('./tasks');
 const { trackEvent, trackException } = require('./metrics');
 
-module.exports = options => {
+module.exports = async options => {
   if (config.isShowVersion) {
     version();
   } else if (config.isShowHelp) {
     help();
   } else {
     trackEvent('start');
-    return runTasks(options).then(() => trackEvent('end'), trackException);
+
+    try {
+      const result = await runTasks(options);
+
+      trackEvent('end');
+      return result;
+    } catch (error) {
+      trackException(error);
+    }
   }
   return Promise.resolve();
 };

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -11,8 +11,6 @@ const log = require('./log');
 const { debug, debugConfig } = require('./debug');
 const { spinner, getSpinner } = require('./spinner');
 
-const noop = () => Promise.resolve();
-
 module.exports = async options => {
   let initSpinner;
 
@@ -181,7 +179,11 @@ module.exports = async options => {
 
     getSpinner().succeed(`Done (in ${Math.floor(process.uptime())}s.)`);
 
-    return noop();
+    return Promise.resolve({
+      changelog,
+      tagName,
+      version
+    });
   } catch (err) {
     initSpinner && initSpinner.fail();
     log.error(err.message);


### PR DESCRIPTION
Return some basic (for now) information from the Tasks Runner: `changelog`, `version`.

The enables `release-it` to be used as a library, and results such as the `version` or the `changelog` can be useful for a more complex build process.