### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add this as a `script` to `package.json`:
 ```
 {
   "name": "my-package",
-  "version": "1.0.0".
+  "version": "1.0.0",
   "scripts": {
     "release": "release-it"
   },


### PR DESCRIPTION
**Motivation:**
Upon going through  the installation process from documentation, I came to find there was `.` instead of `,` . This PR fixes that typo.