### PR TITLE
Fixed dist.tag not working properly

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -193,7 +193,7 @@ module.exports = async options => {
       const remoteUrl = await git.getRemoteUrl();
       const distRepo = repoPathParse(remoteUrl);
       const isSameRepo = git.isSameRepo(repo, distRepo);
-      const shouldTag = (dist.tag && !isSameRepo) || (isSameRepo && tagName !== src.tagName);
+      const shouldTag = (dist.tag && !isSameRepo) || (isSameRepo && tagName !== src.tagName) || (dist.tag && !src.tag);
 
       _.defaults(github, options.github);
       _.defaults(npm, options.npm);


### PR DESCRIPTION
Fixed dist.tag not working when src.tag is disabled.
See issue #333