### PR TITLE
Remove origin from --set-upstream when there is not

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -87,7 +87,7 @@ const getLatestTag = () =>
   );
 
 const push = async ({ pushRepo = '', hasUpstreamBranch, args = '' } = {}) => {
-  const setUpstream = hasUpstreamBranch === false ? `--set-upstream origin/${await getBranchName()}` : '';
+  const setUpstream = hasUpstreamBranch === false ? `--set-upstream ${await getBranchName()}` : '';
   return run(`git push --follow-tags ${args} ${pushRepo} ${setUpstream}`);
 };
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -87,7 +87,7 @@ const getLatestTag = () =>
   );
 
 const push = async ({ pushRepo = '', hasUpstreamBranch, args = '' } = {}) => {
-  const setUpstream = hasUpstreamBranch === false ? `--set-upstream origin ${await getBranchName()}` : '';
+  const setUpstream = hasUpstreamBranch === false ? `--set-upstream origin/${await getBranchName()}` : '';
   return run(`git push --follow-tags ${args} ${pushRepo} ${setUpstream}`);
 };
 


### PR DESCRIPTION
Hello,

When I was trying to release my `canary` releases which are based on my branch `develop`, I got this error: 

```
$ git push --follow-tags  git@github.com:dani8art/hygeia-js.git --set-upstream origin develop
fatal: refs/remotes/origin/HEAD cannot be resolved to branch.
ERROR fatal: refs/remotes/origin/HEAD cannot be resolved to branch.

error An unexpected error occurred: "Command failed.
Exit code: 1
Command: sh
Arguments: -c release-it --verbose --preRelease=canary
Directory: /root/project
Output:
".
info If you think this is a bug, please open a bug report with the information provided in "/root/project/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Exited with code 1
```

After some investigations, I realize that it is caused by this line. This changes could be useful for you.

Thanks,
Daniel.
