### PR TITLE
ci: test Node.js 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "node"
 cache:
   directories:
     - "node_modules"


### PR DESCRIPTION
We should also test the current stable Node.js version which is currently 11.