### PR TITLE
Templates in commit and tag messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Notes:
 
 - Only the settings to override need to be in `.release-it.json`. Everything else will fall back to the [default configuration](conf/release-it.json).
 - You can use `--config` if you want to use another path.
+- In `commitMessage` and `tagAnnotation` you can use variables (like template strings). These are the same variables as in the [command hooks](#command-hooks). 
+  However, be aware that these variables might inject new lines into the actual commands, and their execution will likely fail on windows.
 
 Any option can also be set on the command-line, and will have highest priority. Example:
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -4,7 +4,7 @@ const { bump, runTemplateCommand: run, pushd, copy, npmPublish, popd, mkTmpDir }
 const git = require('./git');
 const githubClient = require('./github-client');
 const prompt = require('./prompt');
-const { truncateLines } = require('./util');
+const { truncateLines, template } = require('./util');
 const { parse: parseVersion } = require('./version');
 const { config } = require('./config');
 const { info, warn, logError } = require('./log');
@@ -147,8 +147,8 @@ module.exports = async options => {
     }
 
     const status = () => git.status();
-    const commit = () => git.commit({ path: '.', message, version, args: commitArgs });
-    const tag = () => git.tag({ version, name: tagName, annotation: tagAnnotation, args: tagArgs });
+    const commit = () => git.commit({ path: '.', message: template(message, options), version, args: commitArgs });
+    const tag = () => git.tag({ version, name: tagName, annotation: template(tagAnnotation, options), args: tagArgs });
     const push = () =>
       git.push({
         pushRepo: src.pushRepo,


### PR DESCRIPTION
Make variables available in `src.commitMessage` and `src.tagAnnotation` by using the template helper, just as in the command hooks.

On Windows, this is somewhat unstable as cmd.exe can't handle the new lines (if any) in the actual `git tag` or `git commit` command. shell.js has an issue for that: shelljs/shelljs#175. I tried to adjust the readme to reflect this limitation. For now, you could only work around this by using a bash (either Git Bash or WSL).

The default configuration however still works fine, as this change also should be fully backwards compatible.

This PR is part of the feature discussed in #380 and #376 