### PR TITLE
fix(github): prevent error referencing this from arrow function

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -24,22 +24,22 @@ const parseErrorMessage = err => {
   return msg;
 };
 
-const handleError = (err, bail) => {
-  const msg = parseErrorMessage(err);
-  const ghError = new GitHubClientError(msg);
-  this.log.verbose(err.errors);
-  debug(err);
-  if (_.includes(NO_RETRIES_NEEDED, err.status)) {
-    return bail(ghError);
-  }
-  throw ghError;
-};
-
 class GitHub extends Release {
   constructor(...args) {
     super(...args);
     this.type = 'GitHub';
     this.options = _.defaults(this.options, defaults);
+  }
+
+  handleError(err, bail) {
+    const msg = parseErrorMessage(err);
+    const ghError = new GitHubClientError(msg);
+    this.log.verbose(err.errors);
+    debug(err);
+    if (_.includes(NO_RETRIES_NEEDED, err.status)) {
+      return bail(ghError);
+    }
+    throw ghError;
   }
 
   getGitHubClient() {
@@ -112,7 +112,7 @@ class GitHub extends Release {
           this.isReleased = true;
           return response.data;
         } catch (err) {
-          return handleError(err, bail);
+          return this.handleError(err, bail);
         }
       },
       {
@@ -145,7 +145,7 @@ class GitHub extends Release {
           this.log.verbose(`octokit releases#uploadAsset: done (${response.data.browser_download_url})`);
           return response.data;
         } catch (err) {
-          return handleError(err, bail);
+          return this.handleError(err, bail);
         }
       },
       {


### PR DESCRIPTION
The latest version tries to reference empty `this` in github.js.