### PR TITLE
Add the `-u` flag to the `conventional-changelog` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ release commit).
 {
   "increment": "conventional:angular",
   "scripts": {
-    "changelog": "npx conventional-changelog -p angular | tail -n +3",
+    "changelog": "npx conventional-changelog -p angular -u | tail -n +3",
     "beforeStage": "npx conventional-changelog -p angular -i CHANGELOG.md -s"
   }
 }


### PR DESCRIPTION
Otherwise the changelog would be empty