### PR TITLE
Support publishConfig.registry

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -108,12 +108,13 @@ class Config {
   }
 
   get npmConfig() {
-    const { version, name, private: isPrivate } = this.localPackageManifest;
+    const { version, name, private: isPrivate, publishConfig } = this.localPackageManifest;
     return {
       version,
       name,
       private: isPrivate,
-      publish: !!name
+      publish: !!name,
+      publishConfig
     };
   }
 

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -1,12 +1,13 @@
 const semver = require('semver');
 const _ = require('lodash');
+const urlJoin = require('url-join');
 const { rejectAfter } = require('./util');
 const debug = require('debug')('release-it:npm');
 const { npmTimeoutError, npmAuthError } = require('./errors');
 
 const REGISTRY_TIMEOUT = 10000;
 const DEFAULT_TAG = 'latest';
-const NPM_BASE_URL = 'https://www.npmjs.com/package/';
+const NPM_DEFAULT_REGISTRY = 'https://www.npmjs.com';
 
 const noop = Promise.resolve();
 
@@ -55,7 +56,8 @@ class npm {
   }
 
   isAuthenticated() {
-    return this.shell.run('npm whoami').then(() => true, () => false);
+    const registry = this.getRegistry(this.options);
+    return this.shell.run(`npm whoami --registry ${registry}`).then(() => true, () => false);
   }
 
   getLatestVersion() {
@@ -63,8 +65,12 @@ class npm {
     return this.shell.run(`npm show ${this.options.name}@${tag} version`).catch(() => null);
   }
 
+  getRegistry() {
+    return _.get(this.options, 'publishConfig.registry', NPM_DEFAULT_REGISTRY);
+  }
+
   getPackageUrl() {
-    return `${NPM_BASE_URL}${this.options.name}`;
+    return urlJoin(this.getRegistry(), 'package', this.options.name);
   }
 
   getTag({ tag = DEFAULT_TAG, version, isPreRelease } = {}) {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "shelljs": "0.8.3",
     "supports-color": "6.1.0",
     "update-notifier": "2.5.0",
+    "url-join": "4.0.0",
     "uuid": "3.3.2",
     "window-size": "1.1.1",
     "yargs-parser": "11.1.1"

--- a/test/config.js
+++ b/test/config.js
@@ -15,7 +15,8 @@ test('should contain default values', t => {
     version: pkg.version,
     name: pkg.name,
     private: pkg.private,
-    publish: true
+    publish: true,
+    publishConfig: pkg.publishConfig
   });
 });
 

--- a/test/npm.js
+++ b/test/npm.js
@@ -7,6 +7,11 @@ test('should return npm package url', t => {
   t.is(npmClient.getPackageUrl(), 'https://www.npmjs.com/package/my-cool-package');
 });
 
+test('should return npm package url (custom registry)', t => {
+  const npmClient = new npm({ name: 'my-cool-package', publishConfig: { registry: 'https://my-registry.com/' } });
+  t.is(npmClient.getPackageUrl(), 'https://my-registry.com/package/my-cool-package');
+});
+
 test('should return tag', t => {
   const npmClient = new npm();
   const tag = npmClient.getTag();
@@ -57,7 +62,7 @@ test('should throw if npm is down', async t => {
 
 test('should throw if user is not authenticated', async t => {
   const run = sinon.stub().resolves();
-  run.withArgs('npm whoami').rejects();
+  run.withArgs('npm whoami --registry https://www.npmjs.com').rejects();
   const npmClient = new npm({
     name: 'pkg',
     publish: true,

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -169,7 +169,7 @@ test.serial('should run tasks without package.json', async t => {
 
     t.is(npmStub.callCount, 4);
     t.is(npmStub.firstCall.args[0], 'npm ping');
-    t.is(npmStub.secondCall.args[0].trim(), 'npm whoami');
+    t.is(npmStub.secondCall.args[0].trim(), 'npm whoami --registry https://www.npmjs.com');
     t.is(npmStub.thirdCall.args[0].trim(), `npm show ${pkgName}@latest version`);
     t.is(npmStub.args[3][0].trim(), 'npm publish . --tag latest');
 

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -275,4 +275,24 @@ test.serial('should run tasks without package.json', async t => {
     t.deepEqual(filtered, scriptsArray);
     spy.restore();
   });
+
+  test.serial('should use pkg.publishConfig.registry', async t => {
+    const { target } = t.context;
+    const pkgName = path.basename(target);
+    const registry = 'https://my-registry.com';
+
+    gitAdd(
+      JSON.stringify({
+        name: pkgName,
+        version: '1.2.3',
+        publishConfig: { registry }
+      }),
+      'package.json',
+      'Add package.json'
+    );
+    await tasks({ npm: { name: pkgName } }, stubs);
+
+    t.is(npmStub.secondCall.args[0].trim(), `npm whoami --registry ${registry}`);
+    t.true(log.log.firstCall.args[0].endsWith(`${registry}/package/${pkgName}`));
+  });
 }


### PR DESCRIPTION
This PR adds support for npm's `publishConfig.registry` option.

Related docs:
- https://docs.npmjs.com/files/package.json#publishconfig
- https://docs.npmjs.com/misc/config#registry

Currently `release-it` fails when publishing to a registry other than the default because [this sanity check](https://github.com/webpro/release-it/blob/10.1.0/lib/npm.js#L58) does not take take into account `publishConfig.registry`.

Additionally, the [output after a successful publish](https://github.com/webpro/release-it/blob/master/lib/tasks.js#L164) makes [strong assumptions on the default registry](https://github.com/webpro/release-it/blob/10.1.0/lib/npm.js#L67).