### PR TITLE
change to execute scripts.changelog even in dry-run mode

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -18,7 +18,8 @@ class Changelog {
           }
         });
       } else {
-        return this.shell.runTemplateCommand(command);
+        const option = { isWrite: false };
+        return this.shell.runTemplateCommand(command, option);
       }
     }
     return noop;

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -55,7 +55,7 @@ class Shell {
 
   runTemplateCommand(command, options) {
     const context = this.config.getOptions();
-    return command ? this.run(format(command, context), Object.assign({}, options, Shell.writes)) : noop;
+    return command ? this.run(format(command, context), Object.assign({}, Shell.writes, options)) : noop;
   }
 
   pushd(path) {


### PR DESCRIPTION
Hi @webpro , this PR about #472 📝 

Contents of tweak: The caller side can specify `{ isWrite: false }` as option in `shell.runTemplateCommand`.

When using "Conventional-Changelog" for the `scripts.changelog`, the content of this PR(#460) is actually necessary. This is probably because the "release-it" does not actually execute the git operation in dry-run mode, so the "Conventional-Changelog" side can't detect the changes. 💭 

About `-u` flag is [here](https://github.com/conventional-changelog/conventional-changelog/blob/97ad96fe893bd5b40ec52e24fe46f4f9cd357a1a/packages/conventional-changelog-cli/cli.js#L40)