### PR TITLE
add dotenv for local .env file variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ The "Releases" tab on GitHub projects links to a page to store the changelog. To
 export GITHUB_TOKEN="f941e0..."
 ```
 
+or inside an `.env` file (make sure to add this file to your `.gitignore`):
+
+```
+GITHUB_TOKEN="f941e0..."
+```
+
 Do not put the actual token in the release-it configuration. It will be read from the `GITHUB_TOKEN` environment
 variable. You can change this variable name by setting the `github.tokenRef` option to something else.
 

--- a/lib/release.js
+++ b/lib/release.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const _ = require('lodash');
 const { parseGitUrl } = require('./util');
 const retry = require('async-retry');

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "cpy": "7.0.1",
     "debug": "4.1.1",
     "deprecated-obj": "1.0.0",
+    "dotenv": "6.2.0",
     "form-data": "2.3.3",
     "git-url-parse": "11.1.2",
     "globby": "9.0.0",


### PR DESCRIPTION
Hey @webpro thanks for the great tool!

This is just a tiny tweak to add [`dotenv`](https://github.com/motdotla/dotenv) and run it in `release.js` to allow `process.env` to pick up a local `.env` file variables.

This should help if someone has both a GitHub Enterprise and personal GitHub project both running release-it, requiring two different keys, but it's also a habit I've picked up since it's incredibly common for [The Twelve-Factor App](http://12factor.net/config).